### PR TITLE
Remove `extern crate`

### DIFF
--- a/src/edit_tree.rs
+++ b/src/edit_tree.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Error, Formatter};
 use std::hash::Hash;
 
+use lazy_static::lazy_static;
 use seqalign::measures::LCSOp;
 use seqalign::measures::LCS;
 use seqalign::op::IndexedOperation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,2 @@
-#[macro_use]
-extern crate lazy_static;
-extern crate failure;
-
 pub mod edit_tree;
 pub use crate::edit_tree::{Apply, ToLowerCharVec, TreeNode};


### PR DESCRIPTION
`extern crate` is not necessary anymore in Rust 2018. Macros can
be used directly.